### PR TITLE
Serve ESPHome web dashboard assets locally

### DIFF
--- a/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c3.yaml
+++ b/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c3.yaml
@@ -14,6 +14,7 @@ wifi:
 
 # So we can use this device standalone, without Home Assitant
 web_server:
+  local: true
 
 # This lets us see logs over USB to understand what the ESP is doing. 
 # Very Helpful during development.

--- a/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c5.yaml
+++ b/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c5.yaml
@@ -14,6 +14,7 @@ wifi:
 
 # So we can use this device standalone, without Home Assitant
 web_server:
+  local: true
 
 # This lets us see logs over USB to understand what the ESP is doing. 
 # Very Helpful during development.

--- a/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c6.yaml
+++ b/firmware/minimal_air_sensor/minimal_air_sensor_esp32_c6.yaml
@@ -14,6 +14,7 @@ wifi:
 
 # So we can use this device standalone, without Home Assitant
 web_server:
+  local: true
 
 # This lets us see logs over USB to understand what the ESP is doing. 
 # Very Helpful during development.

--- a/firmware/minimal_air_sensor/minimal_air_sensor_esp32_s3.yaml
+++ b/firmware/minimal_air_sensor/minimal_air_sensor_esp32_s3.yaml
@@ -14,6 +14,7 @@ wifi:
 
 # So we can use this device standalone, without Home Assitant
 web_server:
+  local: true
 
 # This lets us see logs over USB to understand what the ESP is doing. 
 # Very Helpful during development.


### PR DESCRIPTION
I ran into this issue while trying the project on my own ESP32-C6 setup. I first flashed the release firmware files from the project, and the device came online and I could access the AirAP wifi point, but opening the web interface only showed a blank page.

After doing some chat gpt aided searching, I found that the dashboard UI was trying to load its JavaScript from [https://oi.esphome.io/v2/www.js]. That works when the browser has internet access, but in my case I was using the device in AP-style mode. The ESP itself was reachable, but the dashboard script could not load, so the page stayed blank.

This PR adds:

```
web_server:
  local: true
```
With this enabled, ESPHome embeds and serves the web dashboard assets from the device firmware itself, so the page can load without needing access to the external ESPHome asset URL.

Testing
Rebuilt the ESPHome firmware successfully for the ESP32-C6 target.
Flashed the updated firmware locally and used it to address the blank web UI issue.